### PR TITLE
Component isolation for donation widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
+    "test": "jest",
     "type-check": "tsc --noEmit",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
@@ -96,7 +96,8 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "yarn type-check && lint-staged"
+      "pre-commit": "yarn type-check && lint-staged",
+      "pre-push": "yarn test"
     }
   },
   "commitlint": {

--- a/src/components/DonationWidget/__tests__/machine.spec.ts
+++ b/src/components/DonationWidget/__tests__/machine.spec.ts
@@ -1,8 +1,8 @@
-import donationWizardMachine, { MINIMAL_DONATION } from '../machine';
+import donationMachine, { MINIMAL_DONATION } from '../machine';
 import faker from 'faker';
 
 // Convenient alias for better suite reading
-const machine = donationWizardMachine;
+const machine = donationMachine;
 
 test('starts using one time donation with minimal amount', () => {
   expect(machine.initialState.context).toEqual(

--- a/src/components/DonationWidget/__tests__/machine.spec.ts
+++ b/src/components/DonationWidget/__tests__/machine.spec.ts
@@ -14,19 +14,19 @@ test('starts using one time donation with minimal amount', () => {
   );
 });
 
-describe('when triggering "UPDATE.AMOUNT"', () => {
+describe('when triggering "UPDATE.AMOUNT.*"', () => {
   it('updates donation amount within "one time donation" amount form', () => {
     const newAmount = faker.random.number(20);
     let machineState = machine.initialState;
     machineState = machine.transition(machineState, {
-      type: 'UPDATE.AMOUNT',
+      type: 'UPDATE.AMOUNT.ONCE',
       value: newAmount
     });
 
     expect(machineState.value).toEqual({ amountForm: 'donateOnce' });
     expect(machineState.context).toEqual(
       expect.objectContaining({
-        donationAmount: newAmount
+        donationOnceAmount: newAmount
       })
     );
   });
@@ -36,14 +36,14 @@ describe('when triggering "UPDATE.AMOUNT"', () => {
     let machineState = machine.initialState;
     machineState = machine.transition(machineState, 'START.MONTHLY');
     machineState = machine.transition(machineState, {
-      type: 'UPDATE.AMOUNT',
+      type: 'UPDATE.AMOUNT.MONTHLY',
       value: newAmount
     });
 
     expect(machineState.value).toEqual({ amountForm: 'donateMonthly' });
     expect(machineState.context).toEqual(
       expect.objectContaining({
-        donationAmount: newAmount
+        donationMonthlyAmount: newAmount
       })
     );
   });
@@ -110,10 +110,12 @@ test('goes into process donation after filling all information', () => {
   expect(machineState.value).toEqual('processDonation');
 
   expect(machineState.context).toEqual({
+    billingInformation,
+    cardInformation,
+    donation: {},
     donationType: 'once',
     donationOnceAmount: MINIMAL_DONATION,
     donationMonthlyAmount: MINIMAL_DONATION,
-    cardInformation,
-    billingInformation
+    error: null
   });
 });

--- a/src/components/DonationWidget/components/DonationAddressForm.tsx
+++ b/src/components/DonationWidget/components/DonationAddressForm.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+const DonationAddressForm = ({
+  defaultValues,
+  onSubmit
+}: {
+  defaultValues: {
+    address: string;
+    city: string;
+    zipCode: string;
+    country: string;
+  };
+  onSubmit: (e: React.ChangeEvent<HTMLFormElement>) => void;
+}) => {
+  return (
+    <form className="grid grid-cols-1 gap-4" onSubmit={onSubmit}>
+      <label>
+        Billing address
+        <input defaultValue={defaultValues.address} name="address" />
+      </label>
+      <label>
+        City
+        <input defaultValue={defaultValues.city} name="city" />
+      </label>
+      <label>
+        Zip code:
+        <input defaultValue={defaultValues.zipCode} name="zipCode" />
+      </label>
+      <label>
+        Country
+        <input defaultValue={defaultValues.country} name="country" />
+      </label>
+      <button type="submit">Next</button>
+    </form>
+  );
+};
+
+export default DonationAddressForm;

--- a/src/components/DonationWidget/components/DonationAddressForm.tsx
+++ b/src/components/DonationWidget/components/DonationAddressForm.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 
-const DonationAddressForm = ({
-  defaultValues,
-  onSubmit
-}: {
+interface Props {
   defaultValues: {
     address: string;
     city: string;
@@ -11,7 +8,9 @@ const DonationAddressForm = ({
     country: string;
   };
   onSubmit: (e: React.ChangeEvent<HTMLFormElement>) => void;
-}) => {
+}
+
+const DonationAddressForm: React.FC<Props> = ({ defaultValues, onSubmit }) => {
   return (
     <form className="grid grid-cols-1 gap-4" onSubmit={onSubmit}>
       <label>

--- a/src/components/DonationWidget/components/DonationMonthlyForm.tsx
+++ b/src/components/DonationWidget/components/DonationMonthlyForm.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const DonationMonthlyForm = ({
+  defaultValues,
+  onSubmit
+}: {
+  defaultValues: { amount: number };
+  onSubmit: (e: React.ChangeEvent<HTMLFormElement>) => void;
+}) => {
+  return (
+    <form className="grid grid-cols-1 gap-4" onSubmit={onSubmit}>
+      <label>
+        Donation value:
+        <input defaultValue={defaultValues.amount} name="amount" />
+      </label>
+      <button type="submit">Next</button>
+    </form>
+  );
+};
+
+export default DonationMonthlyForm;

--- a/src/components/DonationWidget/components/DonationMonthlyForm.tsx
+++ b/src/components/DonationWidget/components/DonationMonthlyForm.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 
-const DonationMonthlyForm = ({
-  defaultValues,
-  onSubmit
-}: {
+interface Props {
   defaultValues: { amount: number };
   onSubmit: (e: React.ChangeEvent<HTMLFormElement>) => void;
-}) => {
+}
+
+const DonationMonthlyForm: React.FC<Props> = ({ defaultValues, onSubmit }) => {
   return (
     <form className="grid grid-cols-1 gap-4" onSubmit={onSubmit}>
       <label>

--- a/src/components/DonationWidget/components/DonationOnceForm.tsx
+++ b/src/components/DonationWidget/components/DonationOnceForm.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 
-const DonationOnceForm = ({
-  defaultValues,
-  onSubmit
-}: {
+interface Props {
   defaultValues: { amount: number };
   onSubmit: (e: React.ChangeEvent<HTMLFormElement>) => void;
-}) => {
+}
+
+const DonationOnceForm: React.FC<Props> = ({ defaultValues, onSubmit }) => {
   return (
     <form className="grid grid-cols-1 gap-4" onSubmit={onSubmit}>
       <label>

--- a/src/components/DonationWidget/components/DonationOnceForm.tsx
+++ b/src/components/DonationWidget/components/DonationOnceForm.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const DonationOnceForm = ({
+  defaultValues,
+  onSubmit
+}: {
+  defaultValues: { amount: number };
+  onSubmit: (e: React.ChangeEvent<HTMLFormElement>) => void;
+}) => {
+  return (
+    <form className="grid grid-cols-1 gap-4" onSubmit={onSubmit}>
+      <label>
+        Donation value:
+        <input defaultValue={defaultValues.amount} name="amount" />
+      </label>
+      <button type="submit">Next</button>
+    </form>
+  );
+};
+
+export default DonationOnceForm;

--- a/src/components/DonationWidget/components/DonationPaymentForm.tsx
+++ b/src/components/DonationWidget/components/DonationPaymentForm.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 
-const DonationPaymentForm = ({
-  defaultValues,
-  onSubmit
-}: {
+interface Props {
   defaultValues: { firstName: string; lastName: string; email: string };
   onSubmit: (e: React.ChangeEvent<HTMLFormElement>) => void;
-}) => {
+}
+
+const DonationPaymentForm: React.FC<Props> = ({ defaultValues, onSubmit }) => {
   return (
     <form className="grid grid-cols-1 gap-4" onSubmit={onSubmit}>
       <label>

--- a/src/components/DonationWidget/components/DonationPaymentForm.tsx
+++ b/src/components/DonationWidget/components/DonationPaymentForm.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const DonationPaymentForm = ({
+  defaultValues,
+  onSubmit
+}: {
+  defaultValues: { firstName: string; lastName: string; email: string };
+  onSubmit: (e: React.ChangeEvent<HTMLFormElement>) => void;
+}) => {
+  return (
+    <form className="grid grid-cols-1 gap-4" onSubmit={onSubmit}>
+      <label>
+        First name:
+        <input defaultValue={defaultValues.firstName} name="first-name" />
+      </label>
+      <label>
+        Last name:
+        <input defaultValue={defaultValues.lastName} name="last-name" />
+      </label>
+      <label>
+        Email:
+        <input defaultValue={defaultValues.email} name="email" />
+      </label>
+      <label>
+        Card:
+        <input name="card" />
+      </label>
+      <button type="submit">Next</button>
+    </form>
+  );
+};
+
+export default DonationPaymentForm;

--- a/src/components/DonationWidget/components/index.ts
+++ b/src/components/DonationWidget/components/index.ts
@@ -1,2 +1,4 @@
 export { default as DonationOnceForm } from './DonationOnceForm';
 export { default as DonationMonthlyForm } from './DonationMonthlyForm';
+export { default as DonationPaymentForm } from './DonationPaymentForm';
+export { default as DonationAddressForm } from './DonationAddressForm';

--- a/src/components/DonationWidget/components/index.ts
+++ b/src/components/DonationWidget/components/index.ts
@@ -1,0 +1,2 @@
+export { default as DonationOnceForm } from './DonationOnceForm';
+export { default as DonationMonthlyForm } from './DonationMonthlyForm';

--- a/src/components/DonationWidget/index.tsx
+++ b/src/components/DonationWidget/index.tsx
@@ -1,15 +1,18 @@
 import React, { useEffect } from 'react';
+// TODO: avoid to use AnyEventObject in favor of DonationMachineEvent
+import { AnyEventObject } from 'xstate';
 import { useMachine } from '@xstate/react';
-import donationWizardMachine from './machine';
+import donationMachine from './machine';
 import {
   DonationMachineContext,
   DonationMachineStateValueMap
 } from './machine/types';
-import { DonationOnceForm, DonationMonthlyForm } from './components';
-// TODO: avoid to use AnyEventObject in favor of DonationMachineEvent
-import { AnyEventObject } from 'xstate';
-import DonationPaymentForm from './components/DonationPaymentForm';
-import DonationAddressForm from './components/DonationAddressForm';
+import {
+  DonationOnceForm,
+  DonationMonthlyForm,
+  DonationPaymentForm,
+  DonationAddressForm
+} from './components';
 
 export interface DonationWidgetProps {
   /**
@@ -20,64 +23,51 @@ export interface DonationWidgetProps {
 
 const DonationWidget: React.FC<DonationWidgetProps> = ({ id }) => {
   const [state, send] = useMachine<DonationMachineContext, AnyEventObject>(
-    donationWizardMachine
+    donationMachine
   );
-  const { context: machineCtx } = state;
+  const { context: machineContext } = state;
+  const { billingInformation, cardInformation } = machineContext;
   const machineState: DonationMachineStateValueMap = state.value;
 
   useEffect(() => {
     if (machineState === 'failure') {
-      alert(`Something went wrong ${JSON.stringify(machineCtx)}`);
+      alert(`Something went wrong ${JSON.stringify(machineContext)}`);
       send('RETRY');
     }
   });
 
-  const handleSubmitAmountForm = (e: React.ChangeEvent<HTMLFormElement>) => {
+  const onSubmitAmountForm = (e: React.ChangeEvent<HTMLFormElement>) => {
     const data = new FormData(e.currentTarget);
     const value = Number(data.get('amount'));
 
     if (!value) return;
 
-    send([
-      {
-        type: 'UPDATE.AMOUNT',
-        value
-      },
-      { type: 'NEXT' }
-    ]);
+    send([{ type: 'UPDATE.AMOUNT', value }, { type: 'NEXT' }]);
     e.preventDefault();
   };
 
-  const handleSubmitPaymentInfoForm = (
-    e: React.ChangeEvent<HTMLFormElement>
-  ) => {
+  const onSubmitPaymentInfoForm = (e: React.ChangeEvent<HTMLFormElement>) => {
     const data = new FormData(e.currentTarget);
-    const paymentInformation = {
+
+    send({
+      type: 'NEXT',
       firstName: data.get('first-name'),
       lastName: data.get('last-name'),
       email: data.get('email'),
       cardNumber: data.get('card')
-    };
-
-    send({
-      type: 'NEXT',
-      ...paymentInformation
     });
     e.preventDefault();
   };
 
-  const handleSubmitAddressForm = (e: React.ChangeEvent<HTMLFormElement>) => {
+  const onSubmitAddressForm = (e: React.ChangeEvent<HTMLFormElement>) => {
     const data = new FormData(e.currentTarget);
-    const addressInformation = {
+
+    send({
+      type: 'NEXT',
       address: data.get('address'),
       city: data.get('city'),
       zipCode: data.get('zipCode'),
       country: data.get('country')
-    };
-
-    send({
-      type: 'NEXT',
-      ...addressInformation
     });
     e.preventDefault();
   };
@@ -86,35 +76,35 @@ const DonationWidget: React.FC<DonationWidgetProps> = ({ id }) => {
     <div id={id} className="m-auto" style={{ width: '420px' }}>
       {machineState.amountForm === 'donateOnce' && (
         <DonationOnceForm
-          defaultValues={{ amount: machineCtx.donationOnceAmount }}
-          onSubmit={handleSubmitAmountForm}
+          defaultValues={{ amount: machineContext.donationOnceAmount }}
+          onSubmit={onSubmitAmountForm}
         />
       )}
       {machineState.amountForm === 'donateMonthly' && (
         <DonationMonthlyForm
-          defaultValues={{ amount: machineCtx.donationMonthlyAmount }}
-          onSubmit={handleSubmitAmountForm}
+          defaultValues={{ amount: machineContext.donationMonthlyAmount }}
+          onSubmit={onSubmitAmountForm}
         />
       )}
       {machineState.paymentForm === 'cardForm' && (
         <DonationPaymentForm
           defaultValues={{
-            email: machineCtx.cardInformation.email,
-            firstName: machineCtx.cardInformation.firstName,
-            lastName: machineCtx.cardInformation.lastName
+            email: cardInformation.email,
+            firstName: cardInformation.firstName,
+            lastName: cardInformation.lastName
           }}
-          onSubmit={handleSubmitPaymentInfoForm}
+          onSubmit={onSubmitPaymentInfoForm}
         />
       )}
       {machineState.paymentForm === 'addressForm' && (
         <DonationAddressForm
           defaultValues={{
-            address: machineCtx.billingInformation.address,
-            city: machineCtx.billingInformation.city,
-            zipCode: machineCtx.billingInformation.zipCode,
-            country: machineCtx.billingInformation.country
+            address: billingInformation.address,
+            city: billingInformation.city,
+            zipCode: billingInformation.zipCode,
+            country: billingInformation.country
           }}
-          onSubmit={handleSubmitAddressForm}
+          onSubmit={onSubmitAddressForm}
         />
       )}
     </div>

--- a/src/components/DonationWidget/index.tsx
+++ b/src/components/DonationWidget/index.tsx
@@ -5,8 +5,11 @@ import {
   DonationMachineContext,
   DonationMachineStateValueMap
 } from './machine/types';
+import { DonationOnceForm, DonationMonthlyForm } from './components';
 // TODO: avoid to use AnyEventObject in favor of DonationMachineEvent
 import { AnyEventObject } from 'xstate';
+import DonationPaymentForm from './components/DonationPaymentForm';
+import DonationAddressForm from './components/DonationAddressForm';
 
 export interface DonationWidgetProps {
   /**
@@ -81,86 +84,38 @@ const DonationWidget: React.FC<DonationWidgetProps> = ({ id }) => {
 
   return (
     <div id={id} className="m-auto" style={{ width: '420px' }}>
-      {machineState.amountForm && (
-        <form
-          className="grid grid-cols-1 gap-4"
+      {machineState.amountForm === 'donateOnce' && (
+        <DonationOnceForm
+          defaultValues={{ amount: machineCtx.donationOnceAmount }}
           onSubmit={handleSubmitAmountForm}
-        >
-          <label>
-            Donation value:
-            <input defaultValue={machineCtx.donationOnceAmount} name="amount" />
-          </label>
-          <button type="submit">Next</button>
-        </form>
+        />
+      )}
+      {machineState.amountForm === 'donateMonthly' && (
+        <DonationMonthlyForm
+          defaultValues={{ amount: machineCtx.donationMonthlyAmount }}
+          onSubmit={handleSubmitAmountForm}
+        />
       )}
       {machineState.paymentForm === 'cardForm' && (
-        <form
-          className="grid grid-cols-1 gap-4"
+        <DonationPaymentForm
+          defaultValues={{
+            email: machineCtx.cardInformation.email,
+            firstName: machineCtx.cardInformation.firstName,
+            lastName: machineCtx.cardInformation.lastName
+          }}
           onSubmit={handleSubmitPaymentInfoForm}
-        >
-          <label>
-            First name:
-            <input
-              defaultValue={machineCtx.cardInformation.firstName}
-              name="first-name"
-            />
-          </label>
-          <label>
-            Last name:
-            <input
-              defaultValue={machineCtx.cardInformation.lastName}
-              name="last-name"
-            />
-          </label>
-          <label>
-            Email:
-            <input
-              defaultValue={machineCtx.cardInformation.email}
-              name="email"
-            />
-          </label>
-          <label>
-            Card:
-            <input name="card" />
-          </label>
-          <button type="submit">Next</button>
-        </form>
+        />
       )}
       {machineState.paymentForm === 'addressForm' && (
-        <form
-          className="grid grid-cols-1 gap-4"
+        <DonationAddressForm
+          defaultValues={{
+            address: machineCtx.billingInformation.address,
+            city: machineCtx.billingInformation.city,
+            zipCode: machineCtx.billingInformation.zipCode,
+            country: machineCtx.billingInformation.country
+          }}
           onSubmit={handleSubmitAddressForm}
-        >
-          <label>
-            Billing address
-            <input
-              defaultValue={machineCtx.billingInformation.address}
-              name="address"
-            />
-          </label>
-          <label>
-            City
-            <input
-              defaultValue={machineCtx.billingInformation.city}
-              name="city"
-            />
-          </label>
-          <label>
-            Zip code:
-            <input
-              defaultValue={machineCtx.billingInformation.zipCode}
-              name="zipCode"
-            />
-          </label>
-          <label>
-            Country
-            <input
-              defaultValue={machineCtx.billingInformation.country}
-              name="country"
-            />
-          </label>
-          <button type="submit">Next</button>
-        </form>
+        />
       )}
     </div>
   );

--- a/src/components/DonationWidget/machine/index.ts
+++ b/src/components/DonationWidget/machine/index.ts
@@ -12,7 +12,7 @@ export const MINIMAL_DONATION = 5;
  *
  * https://xstate.js.org/viz/?gist=50ecf807d3b9c049fc58cda690f90594
  */
-const donationWizardMachine = Machine<
+const donationMachine = Machine<
   DonationMachineContext,
   DonationMachineSchema,
   AnyEventObject
@@ -177,4 +177,4 @@ const donationWizardMachine = Machine<
   }
 );
 
-export default donationWizardMachine;
+export default donationMachine;

--- a/src/components/DonationWidget/machine/index.ts
+++ b/src/components/DonationWidget/machine/index.ts
@@ -48,7 +48,7 @@ const donationMachine = Machine<
             on: {
               NEXT: '#donation.paymentForm',
               'START.MONTHLY': 'donateMonthly',
-              'UPDATE.AMOUNT': {
+              'UPDATE.AMOUNT.ONCE': {
                 target: 'donateOnce',
                 actions: ['updateDonationOnceAmount']
               }
@@ -59,7 +59,7 @@ const donationMachine = Machine<
             on: {
               NEXT: '#donation.paymentForm',
               'START.ONCE': 'donateOnce',
-              'UPDATE.AMOUNT': {
+              'UPDATE.AMOUNT.MONTHLY': {
                 target: 'donateMonthly',
                 actions: ['updateDonationMonthlyAmount']
               }

--- a/src/components/DonationWidget/machine/types.ts
+++ b/src/components/DonationWidget/machine/types.ts
@@ -1,7 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
-import { StateValueMap } from 'xstate';
-
 export type BillingInfoEvent = {
   type: 'NEXT';
   address: string;
@@ -19,7 +17,7 @@ export type PaymentInfoEvent = {
 };
 
 export type AmountEvent = {
-  type: 'UPDATE.AMOUNT';
+  type: 'UPDATE.AMOUNT.ONCE' | 'UPDATE.AMOUNT.MONTHLY';
   value: number;
 };
 


### PR DESCRIPTION
**What:**
Separate the code of the forms that we are going to have to accomplish the donation widget

**Why:**
The idea is to reduce the noise when the aesthetics PR come

**How:**
- Create dummy components to hold form compositions for each step of the widget
- Fix the `UPDATE.AMOUNT` event in order to have one for `MONTHLY` and `ONCE` donation type

**Media:**
Doesn't represent any visual change only tech refactor preparing the code.
