### PR TITLE
Add dc-header as a project dependency

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,4 @@
+import { defineCustomElements } from '@debtcollective/dc-header-component/loader';
 import './src/tailwind.css';
+
+defineCustomElements();

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
+    "@debtcollective/dc-header-component": "^1.0.1",
     "@types/lodash.chunk": "^4.2.6",
     "@types/youtube": "^0.0.39",
     "@xstate/react": "^0.8.1",
-    "babel-preset-react-app": "^9.1.2",
     "axios": "^0.20.0",
+    "babel-preset-react-app": "^9.1.2",
     "classnames": "^2.2.6",
     "gatsby": "^2.24.47",
     "gatsby-background-image": "^1.1.2",

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -23,7 +23,20 @@ const Layout: React.FC<Props> = ({ children, title, description }) => {
     <>
       <dc-header
         host="http://debtcollective.org"
-        links='[{"href":"http://debtcollective.org/","text":"About us"}, {"href":"https://community.debtcollective.org/","text":"Community"}, {"href":"https://teespring.com/stores/debt-collective","text":"Store"}]'
+        links={JSON.stringify([
+          {
+            href: 'http://debtcollective.org/',
+            text: 'About us'
+          },
+          {
+            href: 'https://community.debtcollective.org/',
+            text: 'Community'
+          },
+          {
+            href: 'https://teespring.com/stores/debt-collective',
+            text: 'Store'
+          }
+        ])}
       ></dc-header>
       <SEO title={title} description={description} />
       <main className="mt-16">{children}</main>

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -72,13 +72,6 @@ const SEO: React.FC<Props> = ({ description, lang, title }) => {
           content: metaDescription
         }
       ]}
-      script={[
-        {
-          src:
-            'https://unpkg.com/@debtcollective/dc-header-component@latest/dist/header/header.js',
-          type: 'text/javascript'
-        }
-      ]}
     >
       <link
         href="https://fonts.googleapis.com/icon?family=Material+Icons"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,6 +1433,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@debtcollective/dc-header-component@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@debtcollective/dc-header-component/-/dc-header-component-1.0.1.tgz#84762e06b43d6d8ed7c81d84497350c6056aec46"
+  integrity sha512-K8Ky+uJzQEsp11GJcJfJ+dAByLEyTItvwRLyigY+DbW/mYn7kIGx04m34J7kPbZE4BhPDL3W9oVUJl/bs35BiQ==
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"


### PR DESCRIPTION
**What:**
Add dc-header as a project dependency

**Why:**
Relates to: https://app.asana.com/0/1159164196409129/1193491757394465/f

**How:**
- Remove unpkg script from the `SEO` component
- Load header component from the `gastby-browser` file
