### PR TITLE
Donation widget/quick option

### DIFF
--- a/src/components/DonationWidget/__tests__/index.spec.tsx
+++ b/src/components/DonationWidget/__tests__/index.spec.tsx
@@ -21,7 +21,7 @@ const billingInformation = {
   zipCode: faker.address.zipCode(),
   country: faker.address.countryCode()
 };
-const donationAmount = faker.random.number(100);
+const donationAmount = 5;
 const donationResponse = {
   status: 'succeeded',
   message: `Your ${donationAmount} donation has been successfully processed`
@@ -45,9 +45,10 @@ test('send a donation request with all provided information', async () => {
 
   // Give the amount to donate
   expect(screen.getByText(/choose an amount/i)).toBeInTheDocument();
-  const amountInput = screen.getByRole('textbox', { name: /amount/ });
-  userEvent.clear(amountInput);
-  userEvent.type(amountInput, `${donationAmount}`);
+  const amountInput = screen.getByRole('radio', {
+    name: `$${donationAmount} USD`
+  });
+  userEvent.click(amountInput);
   userEvent.click(screen.getByRole('button', { name: /donate/i }));
 
   // Give the billing address
@@ -125,9 +126,10 @@ test('send a donation request with all provided information', async () => {
 test('allows to go back to edit amount', () => {
   render(<DonationWidget />);
 
-  const amountInput = screen.getByRole('textbox', { name: /amount/ });
-  userEvent.clear(amountInput);
-  userEvent.type(amountInput, `${donationAmount}`);
+  const amountInput = screen.getByRole('radio', {
+    name: `$${donationAmount} USD`
+  });
+  userEvent.click(amountInput);
   userEvent.click(screen.getByRole('button', { name: /donate/i }));
 
   const goBackBtn = screen.getByText(/edit amount/i);

--- a/src/components/DonationWidget/components/DonationMonthlyForm.tsx
+++ b/src/components/DonationWidget/components/DonationMonthlyForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DonationQuickOption from './DonationQuickOption';
 import * as DonationWizard from './DonationWizard';
 
 export interface Props {
@@ -14,7 +15,10 @@ const DonationMonthlyForm: React.FC<Props> = ({ defaultValues, onSubmit }) => {
     const formData = new FormData(e.currentTarget);
     const value = Number(formData.get('amount'));
 
-    onSubmit({ value }, e.currentTarget.id);
+    onSubmit(
+      { value: isNaN(value) ? formData.get('other') : value },
+      e.currentTarget.id
+    );
   };
 
   return (
@@ -23,11 +27,11 @@ const DonationMonthlyForm: React.FC<Props> = ({ defaultValues, onSubmit }) => {
         Choose an amount to give per month
       </DonationWizard.Title>
       <DonationWizard.Form id="monthly" onSubmit={handleOnSubmit}>
-        <DonationWizard.Input
-          defaultValue={defaultValues.amount}
+        <DonationQuickOption
+          options={[5, 20, 40, 60, 'other']}
           name="amount"
-          required
-          title="amount to donate"
+          defaultChecked={defaultValues.amount || 20}
+          suffix="USD/mo"
         />
         <DonationWizard.Button type="submit">
           donate monthly

--- a/src/components/DonationWidget/components/DonationOnceForm.tsx
+++ b/src/components/DonationWidget/components/DonationOnceForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DonationQuickOption from './DonationQuickOption';
 import * as DonationWizard from './DonationWizard';
 
 export interface Props {
@@ -14,18 +15,20 @@ const DonationOnceForm: React.FC<Props> = ({ defaultValues, onSubmit }) => {
     const formData = new FormData(e.currentTarget);
     const value = Number(formData.get('amount'));
 
-    onSubmit({ value }, e.currentTarget.id);
+    onSubmit(
+      { value: isNaN(value) ? formData.get('other') : value },
+      e.currentTarget.id
+    );
   };
 
   return (
     <DonationWizard.Container>
       <DonationWizard.Title>Choose an amount to give</DonationWizard.Title>
       <DonationWizard.Form id="once" onSubmit={handleOnSubmit}>
-        <DonationWizard.Input
-          defaultValue={defaultValues.amount}
+        <DonationQuickOption
+          options={[5, 20, 40, 60, 'other']}
           name="amount"
-          required
-          title="amount to donate"
+          defaultChecked={defaultValues.amount || 20}
         />
         <DonationWizard.Button type="submit">donate</DonationWizard.Button>
       </DonationWizard.Form>

--- a/src/components/DonationWidget/components/DonationPhoneInput.tsx
+++ b/src/components/DonationWidget/components/DonationPhoneInput.tsx
@@ -13,7 +13,7 @@ const FormControl = styled.div`
     ${tw`border border-beige-500 rounded-md rounded-r-none`}
   }
 
-  .selected-flag {
+  .selected-flag.selected-flag {
     ${tw`pl-3`}
   }
 `;

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -69,7 +69,7 @@ const DonationQuickOption: React.FC<Props> = ({
                   />
                 )}
                 <label className="text-sm" htmlFor={`option-${option}`}>
-                  {option === 'other' ? option : currencyFormat(option)}{' '}
+                  {option === 'other' ? `Other amount` : currencyFormat(option)}{' '}
                   <span className="text-tiny text-gray-300 normal-case">
                     {option === 'other' ? '' : suffix}
                   </span>
@@ -98,7 +98,6 @@ const QuickOption = styled.div`
       block
       border
       border-beige-500
-      capitalize
       cursor-pointer
       focus:border-blue
       focus:outline-none

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -22,6 +22,15 @@ const currencyFormat = (
     .replace(/\.00/g, '');
 };
 
+const getCurrencySymbol = ({ currency } = { currency: 'USD' }): string => {
+  return new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency
+  })
+    .format(0)
+    .charAt(0);
+};
+
 const DonationQuickOption: React.FC<Props> = ({
   options,
   name,
@@ -76,7 +85,7 @@ const DonationQuickOption: React.FC<Props> = ({
                       style={{ paddingLeft: '1.5rem' }}
                     />
                     <span className="absolute left-0 top-0 py-2 px-3 text-gray-500">
-                      $
+                      {getCurrencySymbol()}
                     </span>
                   </div>
                 )}

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -7,6 +7,7 @@ export interface Props {
   name: string;
   options: Array<number | 'other'>;
   defaultChecked?: number;
+  suffix?: string;
 }
 
 const currencyFormat = (
@@ -24,7 +25,8 @@ const currencyFormat = (
 const DonationQuickOption: React.FC<Props> = ({
   options,
   name,
-  defaultChecked
+  defaultChecked,
+  suffix = 'USD'
 }) => {
   const groups = Math.ceil(options.length / 3);
   const rows = Array(groups)
@@ -64,7 +66,10 @@ const DonationQuickOption: React.FC<Props> = ({
                   />
                 )}
                 <label htmlFor={`option-${option}`}>
-                  {option === 'other' ? option : currencyFormat(option)}
+                  {option === 'other' ? option : currencyFormat(option)}{' '}
+                  <span className="text-tiny text-gray-300">
+                    {option === 'other' ? '' : suffix}
+                  </span>
                 </label>
               </QuickOption>
             );

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -9,6 +9,18 @@ export interface Props {
   defaultChecked?: number;
 }
 
+const currencyFormat = (
+  number: number,
+  { currency } = { currency: 'USD' }
+): string => {
+  return new Intl.NumberFormat('en', {
+    style: 'currency',
+    currency
+  })
+    .format(number)
+    .replace(/\.00/g, '');
+};
+
 const DonationQuickOption: React.FC<Props> = ({
   options,
   name,
@@ -51,7 +63,9 @@ const DonationQuickOption: React.FC<Props> = ({
                     type="text"
                   />
                 )}
-                <label htmlFor={`option-${option}`}>{option}</label>
+                <label htmlFor={`option-${option}`}>
+                  {option === 'other' ? option : currencyFormat(option)}
+                </label>
               </QuickOption>
             );
           })}

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -70,7 +70,7 @@ const DonationQuickOption: React.FC<Props> = ({
                 )}
                 <label className="text-sm" htmlFor={`option-${option}`}>
                   {option === 'other' ? `Other amount` : currencyFormat(option)}{' '}
-                  <span className="text-tiny text-gray-300 normal-case">
+                  <span className="text-xss text-gray-300 normal-case">
                     {option === 'other' ? '' : suffix}
                   </span>
                 </label>

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -1,7 +1,7 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import tw from 'twin.macro';
 import styled from 'styled-components';
-import { Input } from './DonationWizard';
+import { HelpText, Input } from './DonationWizard';
 
 export interface Props {
   name: string;
@@ -28,6 +28,7 @@ const DonationQuickOption: React.FC<Props> = ({
   defaultChecked,
   suffix = 'USD'
 }) => {
+  const [error, setError] = useState(false);
   const groups = Math.ceil(options.length / 3);
   const rows = Array(groups)
     .fill('')
@@ -38,6 +39,10 @@ const DonationQuickOption: React.FC<Props> = ({
     if (e.target.id.includes('other') && inputOther.current) {
       inputOther.current.focus();
     }
+  };
+
+  const onChangeOtherValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setError(Number(e.target.value) > 50000);
   };
 
   return (
@@ -56,17 +61,24 @@ const DonationQuickOption: React.FC<Props> = ({
                   onChange={handleOnChange}
                 />
                 {option === 'other' && (
-                  <Input
-                    className="text-sm"
-                    id="option-other-input"
-                    min="5"
-                    name="other"
-                    placeholder="Other"
-                    ref={inputOther}
-                    step="5"
-                    title="Other"
-                    type="number"
-                  />
+                  <div id="option-other-input" className="relative w-full">
+                    <Input
+                      className="text-sm"
+                      min="5"
+                      max="50000"
+                      name="other"
+                      placeholder="Other"
+                      onChange={onChangeOtherValue}
+                      ref={inputOther}
+                      step="5"
+                      title="Other"
+                      type="number"
+                      style={{ paddingLeft: '1.5rem' }}
+                    />
+                    <span className="absolute left-0 top-0 py-2 px-3 text-gray-500">
+                      $
+                    </span>
+                  </div>
                 )}
                 <label className="text-sm" htmlFor={`option-${option}`}>
                   {option === 'other' ? `Other amount` : currencyFormat(option)}{' '}
@@ -79,6 +91,17 @@ const DonationQuickOption: React.FC<Props> = ({
           })}
         </QuickOptionRow>
       ))}
+      {error && (
+        <HelpText>
+          We are only able to process up to $50,000 online. Want to donate more?{' '}
+          <a
+            className="text-primary underline"
+            href="mailto:admin@debtcollective.org"
+          >
+            contact us
+          </a>
+        </HelpText>
+      )}
     </QuickOptionContainer>
   );
 };

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -1,0 +1,117 @@
+import React, { useRef } from 'react';
+import tw from 'twin.macro';
+import styled from 'styled-components';
+import { Input } from './DonationWizard';
+
+export interface Props {
+  name: string;
+  options: Array<number | 'other'>;
+  defaultChecked?: number;
+}
+
+const DonationQuickOption: React.FC<Props> = ({
+  options,
+  name,
+  defaultChecked
+}) => {
+  const groups = Math.ceil(options.length / 3);
+  const rows = Array(groups)
+    .fill('')
+    .map((_, i) => options.slice(i * 3, (i + 1) * 3));
+
+  const inputOther = useRef<HTMLInputElement>(null);
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.id.includes('other') && inputOther.current) {
+      inputOther.current.focus();
+    }
+  };
+
+  return (
+    <QuickOptionContainer>
+      {rows.map((row, i) => (
+        <QuickOptionRow key={`row-${i}`}>
+          {row.map((option) => {
+            return (
+              <QuickOption key={`key-${option}`}>
+                <input
+                  defaultChecked={option === defaultChecked}
+                  id={`option-${option}`}
+                  name={name}
+                  type="radio"
+                  value={option}
+                  onChange={handleOnChange}
+                />
+                {option === 'other' && (
+                  <Input
+                    ref={inputOther}
+                    id="option-other-input"
+                    name="other"
+                    placeholder="Other"
+                    title="Other"
+                    type="text"
+                  />
+                )}
+                <label htmlFor={`option-${option}`}>{option}</label>
+              </QuickOption>
+            );
+          })}
+        </QuickOptionRow>
+      ))}
+    </QuickOptionContainer>
+  );
+};
+
+export default DonationQuickOption;
+
+const QuickOptionRow = styled.div`
+  ${tw`flex flex-wrap justify-between -ml-2 mt-2`}
+`;
+
+const QuickOption = styled.div`
+  ${tw`flex w-1/3 last:flex-1 ml-2`}
+
+  label {
+    ${tw`
+      bg-white-100
+      block
+      border
+      border-beige-500
+      capitalize
+      cursor-pointer
+      focus:border-blue
+      focus:outline-none
+      py-2 px-3
+      rounded-md
+      text-center
+      w-full
+    `}
+  }
+
+  input {
+    ${tw`appearance-none`}
+
+    &:checked + label {
+      ${tw`bg-blue border-blue`}
+    }
+  }
+
+  #option-other {
+    &-input {
+      ${tw`hidden mt-0`}
+    }
+
+    &:checked ~ label {
+      ${tw`hidden`}
+    }
+
+    &:checked ~ #option-other-input {
+      ${tw`block`}
+    }
+  }
+`;
+
+const QuickOptionContainer = styled.div`
+  ${QuickOptionRow}:firt-child {
+    ${tw`mt-0`}
+  }
+`;

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -57,12 +57,14 @@ const DonationQuickOption: React.FC<Props> = ({
                 />
                 {option === 'other' && (
                   <Input
-                    ref={inputOther}
                     id="option-other-input"
+                    min="5"
                     name="other"
                     placeholder="Other"
+                    ref={inputOther}
+                    step="5"
                     title="Other"
-                    type="text"
+                    type="number"
                   />
                 )}
                 <label htmlFor={`option-${option}`}>

--- a/src/components/DonationWidget/components/DonationQuickOption.tsx
+++ b/src/components/DonationWidget/components/DonationQuickOption.tsx
@@ -57,6 +57,7 @@ const DonationQuickOption: React.FC<Props> = ({
                 />
                 {option === 'other' && (
                   <Input
+                    className="text-sm"
                     id="option-other-input"
                     min="5"
                     name="other"
@@ -67,9 +68,9 @@ const DonationQuickOption: React.FC<Props> = ({
                     type="number"
                   />
                 )}
-                <label htmlFor={`option-${option}`}>
+                <label className="text-sm" htmlFor={`option-${option}`}>
                   {option === 'other' ? option : currencyFormat(option)}{' '}
-                  <span className="text-tiny text-gray-300">
+                  <span className="text-tiny text-gray-300 normal-case">
                     {option === 'other' ? '' : suffix}
                   </span>
                 </label>

--- a/src/components/DonationWidget/components/DonationWizard.tsx
+++ b/src/components/DonationWidget/components/DonationWizard.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
   ${tw`grid grid-cols-1 gap-0 max-w-full border border-beige-500 bg-beige-100 rounded overflow-hidden`}
-  width: 28rem;
+  width: 24rem;
 `;
 
 export const Box = styled.div`

--- a/src/components/DonationWidget/stories/DonationMonthlyForm.stories.tsx
+++ b/src/components/DonationWidget/stories/DonationMonthlyForm.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import faker from 'faker';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { DonationMonthlyForm } from '../components';
 import { Props as DonationMonthlyFormProps } from '../components/DonationMonthlyForm';
@@ -18,5 +17,5 @@ const MonthlyFormTemplate: Story<DonationMonthlyFormProps> = (args) => (
 export const MonthlyForm = MonthlyFormTemplate.bind({});
 
 MonthlyForm.args = {
-  defaultValues: { amount: faker.random.number(100) }
+  defaultValues: { amount: 20 }
 };

--- a/src/components/DonationWidget/stories/DonationOnceForm.stories.tsx
+++ b/src/components/DonationWidget/stories/DonationOnceForm.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import faker from 'faker';
 import { Story, Meta } from '@storybook/react/types-6-0';
 import { DonationOnceForm } from '../components';
 import { Props as DonationOnceFormProps } from '../components/DonationOnceForm';
@@ -18,5 +17,6 @@ const OnceFormTemplate: Story<DonationOnceFormProps> = (args) => (
 export const OnceForm = OnceFormTemplate.bind({});
 
 OnceForm.args = {
-  defaultValues: { amount: faker.random.number(100) }
+  defaultValues: { amount: 5 },
+  onSubmit: (data) => alert(JSON.stringify(data))
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,6 +54,7 @@ module.exports = {
         sans: ['Roboto', 'Helvetica', 'Arial', 'sans-serif']
       },
       fontSize: {
+        tiny: '0.6rem',
         '7xl': '6rem',
         '9xl': '7.5rem'
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -54,7 +54,7 @@ module.exports = {
         sans: ['Roboto', 'Helvetica', 'Arial', 'sans-serif']
       },
       fontSize: {
-        tiny: '0.6rem',
+        xss: '0.6rem',
         '7xl': '6rem',
         '9xl': '7.5rem'
       },


### PR DESCRIPTION
**What:**
Allow user to quick select predefined amount values

**Why:**
relates to Development of Donation widget for upcoming release

**How:**
- Add new `QuickOption` component within the donation widget
- Integrate new component into Donation Once and Monthly forms

> Disclaimer: it may be some complexity that we can improve/remove over the next iterations of the widget. Nevertheless, bare in mind that the layout of `QuickOption` has
been done trying to facilitate the iteration over the options without breaking the way all the options are place.

**Media:**
![image](https://user-images.githubusercontent.com/1425162/93666671-4f373f00-fa80-11ea-8736-8007ba5caa62.png)

https://www.loom.com/share/ce0fd7ac65ab4176baa4d514e53c936f
