### PR TITLE
feat(debt-union): show actual user count from discourse

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -50,6 +50,18 @@ module.exports = {
         '@hooks': path.join(__dirname, 'src/hooks'),
         '@static': path.join(__dirname, 'static')
       }
+    },
+    {
+      resolve: 'gatsby-source-custom-api',
+      options: {
+        url: `${process.env.GATSBY_COMMUNITY_URL}/about.json`,
+        rootKey: 'about',
+        schemas: {
+          about: `
+            user_count: Int
+          `
+        }
+      }
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gatsby-plugin-root-import": "^2.0.5",
     "gatsby-plugin-sharp": "^2.6.29",
     "gatsby-plugin-typescript": "^2.4.18",
+    "gatsby-source-custom-api": "2.1.4",
     "gatsby-source-filesystem": "^2.3.26",
     "gatsby-transformer-sharp": "^2.5.13",
     "lodash.chunk": "^4.2.0",

--- a/src/sections/OweTheBank/index.tsx
+++ b/src/sections/OweTheBank/index.tsx
@@ -3,7 +3,7 @@ import BackgroundImage from 'gatsby-background-image';
 import { useStaticQuery, graphql } from 'gatsby';
 
 const OweTheBank = () => {
-  const { desktop, medium, small } = useStaticQuery(graphql`
+  const { desktop, medium, small, allAbout } = useStaticQuery(graphql`
     query {
       desktop: file(relativePath: { eq: "owe-the-bank.png" }) {
         childImageSharp {
@@ -26,8 +26,24 @@ const OweTheBank = () => {
           }
         }
       }
+      allAbout {
+        nodes {
+          about {
+            stats {
+              user_count
+            }
+          }
+        }
+      }
     }
   `);
+
+  // Fetch user count from Discourse
+  const {
+    about: {
+      stats: { user_count: userCount }
+    }
+  } = allAbout.nodes[0];
 
   // Art-Direction Array
   const backgroundArtDirectionStack = [
@@ -49,13 +65,13 @@ const OweTheBank = () => {
     >
       <div className="order-2 w-full max-w-8xl mx-auto">
         <p className=" text-white text-xl font-semibold text-right lg:text-2xl">
-          With over 33K members,
+          With {userCount} members,
         </p>
         <p className=" text-white text-xl font-semibold text-right lg:text-2xl">
           together, we own the bank!
         </p>
         <h2 className=" text-white font-bold leading-20 text-right text-6xl mt-2 lg:mt-5 lg:text-7xl">
-          33,021
+          {userCount}
         </h2>
       </div>
     </BackgroundImage>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9671,6 +9671,19 @@ gatsby-core-utils@^1.3.19:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^1.3.21:
+  version "1.3.21"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.21.tgz#fa988d04683527b1713c41df10c081712994781c"
+  integrity sha512-oaHdrfnip0u1pMVkO5O+R6YxJ6XBi662YCAPVj4G6DCQG9ngJOKNdaHXU1G9Mjalq6Kb/rNWNRMjOU5u78BdKQ==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-design-tokens@^2.0.2:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/gatsby-design-tokens/-/gatsby-design-tokens-2.0.11.tgz#b0cf12abc283c73e13de3f610fbcec5fce3e7b48"
@@ -9910,6 +9923,36 @@ gatsby-recipes@^0.2.23:
     xstate "^4.9.1"
     yoga-layout-prebuilt "^1.9.6"
     yup "^0.27.0"
+
+gatsby-source-custom-api@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/gatsby-source-custom-api/-/gatsby-source-custom-api-2.1.4.tgz#6999497feede30f69bc298582ec1564738be4496"
+  integrity sha512-ZYw2zxwmgMZA6Q9I2YyEM8ZQUtDlY+jNeL66i7a7n9WzIqiR4WoMYYoj9OJlr6Y1AwSSrfuJqRtgLJhA5zvu1Q==
+  dependencies:
+    gatsby-source-filesystem "^2.0.29"
+    node-fetch "^2.3.0"
+    uuid "^3.3.2"
+
+gatsby-source-filesystem@^2.0.29:
+  version "2.3.31"
+  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.3.31.tgz#a97a30e64a10443068846c08a686fefb2c6ecf7c"
+  integrity sha512-otAoUpSh7CRPHWG+4T1lY4V3Tr35lKgBc5tG9iukFRiRf4PvPEvQsd/1b1UfE/RtvLnhOHJj/ED6jpHIKKzBMw==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    better-queue "^3.8.10"
+    bluebird "^3.7.2"
+    chokidar "^3.4.2"
+    file-type "^12.4.2"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^1.3.21"
+    got "^9.6.0"
+    md5-file "^3.2.3"
+    mime "^2.4.6"
+    pretty-bytes "^5.4.1"
+    progress "^2.0.3"
+    read-chunk "^3.2.0"
+    valid-url "^1.0.9"
+    xstate "^4.13.0"
 
 gatsby-source-filesystem@^2.3.26:
   version "2.3.29"
@@ -14280,7 +14323,7 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@2.6.1, node-fetch@^2.5.0, node-fetch@^2.6.0:
+node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -16342,7 +16385,7 @@ prettier@^2.0.5:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
   integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
 
-pretty-bytes@^5.3.0:
+pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.4.1.tgz#cd89f79bbcef21e3d21eb0da68ffe93f803e884b"
   integrity sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==


### PR DESCRIPTION
**What:** show actual user count from discourse

![image](https://user-images.githubusercontent.com/849872/94624321-c9837280-027b-11eb-95c3-56f5247d8331.png)

See it here 👉  https://deploy-preview-39--tdc-home.netlify.app/debt-union/

**Why:** Closes https://app.asana.com/0/1196225495304457/1196225495304514

**How:**

- Add [gatsby-source-custom-api](https://www.gatsbyjs.com/plugins/gatsby-source-custom-api/) lib.
- Use gatsby-source-custom-api to fetch from Discourse about.json endpoint and display user_count in the Join the Union page.

**Notes:**

If Discourse is not running this will return an error. I couldn't find any information on how to prevent this by using this plugin. If you think of a better approach please let me know.