### PR TITLE
Enable country selection on the phone number input

### DIFF
--- a/src/components/Donation/components/DonationPhoneInput.tsx
+++ b/src/components/Donation/components/DonationPhoneInput.tsx
@@ -12,10 +12,6 @@ const FormControl = styled.div`
   .flag-dropdown {
     ${tw`border border-beige-500 rounded-md rounded-r-none`}
   }
-
-  .selected-flag.selected-flag {
-    ${tw`pl-3`}
-  }
 `;
 
 const DonationPhoneInput: React.FC<InputHTMLAttributes<HTMLInputElement>> = ({
@@ -33,7 +29,6 @@ const DonationPhoneInput: React.FC<InputHTMLAttributes<HTMLInputElement>> = ({
       <PhoneInput
         country="us"
         containerClass="phone-input-element"
-        disableDropdown={true}
         value={value}
         onChange={handleOnChange}
         inputProps={rest}

--- a/src/components/Donation/components/DonationWizard.tsx
+++ b/src/components/Donation/components/DonationWizard.tsx
@@ -3,7 +3,7 @@ import tw from 'twin.macro';
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  ${tw`grid grid-cols-1 gap-0 max-w-full border border-beige-500 bg-beige-100 rounded overflow-hidden w-full`}
+  ${tw`grid grid-cols-1 gap-0 max-w-full border border-beige-500 bg-beige-100 rounded overflow-visible w-full`}
 `;
 
 export const BottomMessage = styled.div`


### PR DESCRIPTION
**What:**
Enable country selection on the phone number input

**Why:**
Closes: https://app.asana.com/0/1159164196409129/1196508164875320/f

**How:**
`react-phone-input-2` already includes a dropdown for the country codes, however, the `disableDropdown` prop was set as `true`, by removing this prop the country selection was enabled

#### Media
https://www.loom.com/share/b91ff7bf0ba746449418d8a557b026df
