### PR TITLE
Fix SEO tags rendering on Facebook and Twitter

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -29,8 +29,8 @@ module.exports = {
     url: siteUrl
   },
   plugins: [
-    `gatsby-plugin-typescript`,
     `gatsby-plugin-react-helmet`,
+    `gatsby-plugin-typescript`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-postcss`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,9 @@
 module.exports = {
   future: {
+    purgeLayersByDefault: true,
     removeDeprecatedGapUtilities: true
   },
-  purge: [],
+  purge: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     colors: {
       'black-100': '#1C1C1C',


### PR DESCRIPTION
**What:** Fix SEO tags rendering on Facebook and Twitter

For some reason SEO tags are not rendering correctly, I did some research and this can be related to Tailwind or how Gatsby works with React Helmet.

https://github.com/gatsbyjs/gatsby/issues/9979
https://github.com/gatsbyjs/gatsby/issues/22908#issuecomment-627201300

**Why:** Fixes https://app.asana.com/0/1196225495304457/1196225495304524

**How:**

- Enable `purge` for tailwindcss

