### PR TITLE
fix(purgecss): whitelist dynamic bg colors

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,23 @@ module.exports = {
     purgeLayersByDefault: true,
     removeDeprecatedGapUtilities: true
   },
-  purge: ['./src/**/*.{js,ts,jsx,tsx}'],
+  purge: {
+    content: ['./src/**/*.{js,ts,jsx,tsx}'],
+    options: {
+      // We whitelist the Colors enum classes to keep them after purge
+      // TODO: find a way to import the enum and build the classes array
+      whitelist: [
+        'bg-blue',
+        'bg-gray',
+        'bg-green',
+        'bg-pink',
+        'bg-primary',
+        'bg-purple',
+        'bg-white',
+        'bg-yellow'
+      ]
+    }
+  },
   theme: {
     colors: {
       'black-100': '#1C1C1C',


### PR DESCRIPTION
**What:** whitelist dynamic bg colors

**before**
![image](https://user-images.githubusercontent.com/849872/95393509-5b186300-08c0-11eb-9371-688ab11f9b53.png)

**after**
![image](https://user-images.githubusercontent.com/849872/95392962-4a1b2200-08bf-11eb-9752-c6427e2048ce.png)

**Why:** Fixes an issue with member benefits circle bg colors

**How:**

- whitelist dynamic generated background color classes.
