### PR TITLE
Address TypeScript errors and set back the ts scan on lint staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "jest",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --project tsconfig.json",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
@@ -111,7 +111,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged",
+      "pre-commit": "yarn type-check && lint-staged",
       "pre-push": "yarn test"
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "removeComments": true,
     "module": "commonjs",
     "skipLibCheck": true,
     // @TODO: Replace target for Node12 https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "skipLibCheck": true,
     // @TODO: Replace target for Node12 https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
     "target": "esnext",
     "jsx": "react",
@@ -20,6 +21,6 @@
       "@hooks/*": ["src/hooks/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src/*"],
   "exclude": ["node_modules", "public", ".cache"]
 }


### PR DESCRIPTION
**What:**
1. Enable type check before commit
2. Address config warnings by webhint

**Why:**
Closes https://app.asana.com/0/1196225495304457/1195530778765045

**How:**
1. https://stackoverflow.com/a/56268670/1422380 as basically the errors where due to libraries type declaration
2. Webhint suggest actions to take and we just follow those