### PR TITLE
refactor(membership-widget): rename union widget to be membership widget

### DIFF
--- a/src/components/Donation/MembershipWidget.tsx
+++ b/src/components/Donation/MembershipWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useMachine } from '@xstate/react';
-import unionMachine from './machines/unionMachine';
+import membershipMachine from './machines/membershipMachine';
 import { DonationMachineStateValueMap } from './machines/donationType';
 import {
   DonationMonthlyForm,
@@ -38,15 +38,15 @@ export interface Props {
   className?: string;
 }
 
-const UnionWidget: React.FC<Props> = ({ id, className }) => {
-  const [state, send] = useMachine(unionMachine);
+const MembershipWidget: React.FC<Props> = ({ id, className }) => {
+  const [state, send] = useMachine(membershipMachine);
   const { context: machineContext } = state;
   const { addressInformation, personalInformation } = machineContext;
   const machineState: DonationMachineStateValueMap = state.value;
 
   useEffect(() => {
     /**
-     * Initialize the UnionWidget to render on
+     * Initialize the MembershipWidget to render on
      * monthly subscription state.
      */
     send('START.MONTHLY');
@@ -116,12 +116,12 @@ const UnionWidget: React.FC<Props> = ({ id, className }) => {
       className={`m-auto w-full ${className}`}
       style={{ maxWidth: '24rem' }}
     >
-      {machineState === 'processUnion' && <DonationLoading />}
+      {machineState === 'processMembership' && <DonationLoading />}
       {machineState === 'success' && (
         <DonationThankYou>
-          <p className="text-center mt-4 mb-0 text-sm px-6">
+          <p className="px-6 mt-4 mb-0 text-sm text-center">
             {machineContext.api.donation?.message}. Go to{' '}
-            <Link className="text-primary underline" to="/hub">
+            <Link className="underline text-primary" to="/hub">
               your member hub
             </Link>{' '}
             to continue the process
@@ -176,7 +176,7 @@ const UnionWidget: React.FC<Props> = ({ id, className }) => {
           onSubmit={onSubmitAddressForm}
         />
       )}
-      <p className="text-white text-xss text-center mt-2 px-4">
+      <p className="px-4 mt-2 text-center text-white text-xss">
         After processing your donation an account will be created for you
         providing access to all Debt Collective Union Member benefits.
       </p>
@@ -184,4 +184,4 @@ const UnionWidget: React.FC<Props> = ({ id, className }) => {
   );
 };
 
-export default UnionWidget;
+export default MembershipWidget;

--- a/src/components/Donation/__tests__/MembershipWidget.spec.tsx
+++ b/src/components/Donation/__tests__/MembershipWidget.spec.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import faker from 'faker';
-import UnionWidget from '../UnionWidget';
-import * as HTTPService from '../api/union';
+import MembershipWidget from '../MembershipWidget';
+import * as HTTPService from '../api/membership';
 
 jest.mock('../components/StripeCardInput');
 jest.mock('../components/DonationCountryDropdown');
@@ -24,7 +24,7 @@ const donationResponse = {
   status: 'succeeded',
   message: 'Your donation has been successfully processed'
 };
-const sendDonationSpy = jest.spyOn(HTTPService, 'sendUnionDonation');
+const sendDonationSpy = jest.spyOn(HTTPService, 'sendMembershipDonation');
 
 beforeAll(() => {
   // @ts-ignore
@@ -40,7 +40,7 @@ afterEach(() => {
 test('allows to skip the payment form and complete flow using zero donation selection', async () => {
   const donationAmount = 0;
   const regexAmount = new RegExp(`Paying ${donationAmount}`, 'i');
-  render(<UnionWidget />);
+  render(<MembershipWidget />);
 
   const zeroOptionBtn = screen.getByRole('button', { name: /zero/i });
   userEvent.click(zeroOptionBtn);
@@ -118,7 +118,7 @@ test('allows to skip the payment form and complete flow using zero donation sele
 test('allows to complete flow using an amount donation selection', async () => {
   const donationAmount = 5;
   const regexAmount = new RegExp(`Paying ${donationAmount}`, 'i');
-  render(<UnionWidget />);
+  render(<MembershipWidget />);
 
   // Select an amount
   userEvent.click(

--- a/src/components/Donation/api/membership.ts
+++ b/src/components/Donation/api/membership.ts
@@ -1,4 +1,4 @@
-import { UnionMachineContext } from '../machines/unionMachine';
+import { MembershipMachineContext } from '../machines/membershipMachine';
 
 const DONATION_API_URL = `${process.env.GATSBY_MEMBERSHIP_API_URL}`;
 
@@ -8,7 +8,9 @@ interface DonationResponse {
   message?: string;
 }
 
-export const sendUnionDonation = async (context: UnionMachineContext) => {
+export const sendMembershipDonation = async (
+  context: MembershipMachineContext
+) => {
   const { personalInformation, addressInformation, paymentServices } = context;
 
   const grecaptcha = (window as any).grecaptcha;

--- a/src/components/Donation/index.tsx
+++ b/src/components/Donation/index.tsx
@@ -1,4 +1,4 @@
 export { default as DonationWidget } from './DonationWidget';
 export type { Props as DonationWidgetProps } from './DonationWidget';
-export { default as UnionWidget } from './UnionWidget';
-export type { Props as UnionWidgetProps } from './UnionWidget';
+export { default as MembershipWidget } from './MembershipWidget';
+export type { Props as MembershipWidgetProps } from './MembershipWidget';

--- a/src/components/Donation/machines/__tests__/membershipMachine.spec.ts
+++ b/src/components/Donation/machines/__tests__/membershipMachine.spec.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import faker from 'faker';
-import unionMachine, {
+import membershipMachine, {
   AddressData,
   MINIMAL_DONATION,
   PaymentServices,
   PersonalData
-} from '../unionMachine';
+} from '../membershipMachine';
 
 // Convenient alias for better suite reading
-const machine = unionMachine;
+const machine = membershipMachine;
 
-test('goes into process union state after filling all information', () => {
+test('goes into process membership state after filling all information', () => {
   const personalInformation: PersonalData = {
     firstName: faker.name.findName(),
     lastName: faker.name.lastName(),
@@ -67,5 +67,5 @@ test('goes into process union state after filling all information', () => {
       stripeToken: { id: 'fake-stripe-token' }
     }
   });
-  expect(machineState.value).toEqual('processUnion');
+  expect(machineState.value).toEqual('processMembership');
 });

--- a/src/components/Donation/stories/MembershipWidget.stories.tsx
+++ b/src/components/Donation/stories/MembershipWidget.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 
-import { UnionWidget as Widget, UnionWidgetProps } from '../';
+import { MembershipWidget as Widget, MembershipWidgetProps } from '..';
 
 export default {
   title: 'Example/DonationWidget'
@@ -10,12 +10,12 @@ export default {
 /**
  * Showcase the widget composition with all forms
  */
-const UnionWidgetTemplate: Story<UnionWidgetProps> = (args) => (
+const MembershipWidgetTemplate: Story<MembershipWidgetProps> = (args) => (
   <Widget {...args} />
 );
 
-export const UnionWidget = UnionWidgetTemplate.bind({});
+export const MembershipWidget = MembershipWidgetTemplate.bind({});
 
-UnionWidget.args = {
+MembershipWidget.args = {
   id: 'union-widget'
 };

--- a/src/sections/YouAreNotALoan/index.tsx
+++ b/src/sections/YouAreNotALoan/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 import BackgroundImage from 'gatsby-background-image';
-import { UnionWidget } from '@components/Donation';
+import { MembershipWidget } from '@components/Donation';
 
 const YouAreNotALoan: React.FC = () => {
   const { desktop, medium, small } = useStaticQuery(graphql`
@@ -59,7 +59,7 @@ const YouAreNotALoan: React.FC = () => {
               Join a growing community of debtors organizing to cancel debts and
               build financial and political power
             </p>
-            <UnionWidget className="ml-0 mr-auto md:mr-0" />
+            <MembershipWidget className="ml-0 mr-auto md:mr-0" />
           </div>
         </div>
       </BackgroundImage>


### PR DESCRIPTION
**What:**
Rename union widget to be membership widget

**Why:**
Closes: https://app.asana.com/0/1168997577035609/1195530778765041/f

**How:**
Renaming the components and files related to the union widget, including the union machine into a membership machine
