### PR TITLE
Feat/donation membership widgets error handling

### DIFF
--- a/src/components/Donation/DonationWidget.tsx
+++ b/src/components/Donation/DonationWidget.tsx
@@ -42,7 +42,10 @@ const DonationWidget: React.FC<Props> = ({ id, className }) => {
    */
   useEffect(() => {
     if (machineState === 'failure') {
-      console.error('Machine falls on failure status', machineContext.errors);
+      console.error(
+        'Machine falls on failure status',
+        machineContext.donation.errors
+      );
       send('RETRY');
     }
   });
@@ -123,7 +126,7 @@ const DonationWidget: React.FC<Props> = ({ id, className }) => {
       )}
       {machineState.paymentForm === 'cardForm' && (
         <DonationPaymentForm
-          errors={machineContext.errors}
+          errors={machineContext.donation.errors}
           amount={machineContext.donationOnceAmount}
           defaultValues={{
             email: cardInformation.email,

--- a/src/components/Donation/__tests__/DonationWidget.spec.tsx
+++ b/src/components/Donation/__tests__/DonationWidget.spec.tsx
@@ -107,12 +107,12 @@ test('send a donation request with all provided information', async () => {
       cardInformation,
       donation: {
         message: '',
-        status: ''
+        status: '',
+        errors: null
       },
       donationType: 'once',
       donationOnceAmount: donationAmount,
       donationMonthlyAmount: MINIMAL_DONATION,
-      errors: null,
       paymentServices: {
         stripe: expect.any(Object),
         stripeToken: {

--- a/src/components/Donation/__tests__/MembershipWidget.spec.tsx
+++ b/src/components/Donation/__tests__/MembershipWidget.spec.tsx
@@ -104,7 +104,7 @@ test('allows to skip the payment form and complete flow using zero donation sele
     api: {
       // TODO: check on integration time seems to be something wrong
       donation: undefined,
-      error: undefined
+      errors: undefined
     },
     donationType: 'month',
     donationMonthlyAmount: donationAmount,
@@ -189,7 +189,7 @@ test('allows to complete flow using an amount donation selection', async () => {
     api: {
       // TODO: check on integration time seems to be something wrong
       donation: undefined,
-      error: undefined
+      errors: undefined
     },
     donationType: 'month',
     donationMonthlyAmount: donationAmount,

--- a/src/components/Donation/components/DonationPaymentForm.tsx
+++ b/src/components/Donation/components/DonationPaymentForm.tsx
@@ -10,10 +10,12 @@ import StripeCardInput, { DonationPaymentProvider } from './StripeCardInput';
 import { STRIPE_API_KEY } from '../utils/stripe';
 import { DonationDropdown, DonationPhoneInput } from '.';
 import chapters from '../constants/chapters';
+import { EMPTY_SPACE } from '../constants/placeholders';
+import { DEFAULT_ERROR } from '../constants/errors';
 
 export interface Props {
   amount: number;
-  errors: { [key: string]: [string] } | null;
+  errors?: string[] | null;
   defaultValues: {
     firstName: string;
     lastName: string;
@@ -42,6 +44,7 @@ const DonationPaymentForm: React.FC<Props> = ({
   const [paymentProvider, setPaymentProvider] = useState<
     DonationPaymentProvider | undefined
   >();
+  const errorMessage: string | undefined = errors?.join(EMPTY_SPACE);
 
   const handleOnSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
     e.persist();
@@ -146,9 +149,9 @@ const DonationPaymentForm: React.FC<Props> = ({
           </Elements>
         ) : null}
         {errors !== null ? (
-          <DonationWizard.HelpText role="alert">
-            Error processing your request. Please try again
-          </DonationWizard.HelpText>
+          <DonationWizard.ErrorText role="alert">
+            {errorMessage || DEFAULT_ERROR}
+          </DonationWizard.ErrorText>
         ) : null}
         <DonationWizard.Button
           type="submit"

--- a/src/components/Donation/components/DonationQuickOption.tsx
+++ b/src/components/Donation/components/DonationQuickOption.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import tw from 'twin.macro';
 import styled from 'styled-components';
-import { HelpText, Input } from './DonationWizard';
+import { ErrorText, Input } from './DonationWizard';
 
 export interface Props {
   name: string;
@@ -105,7 +105,7 @@ const DonationQuickOption: React.FC<Props> = ({
         </QuickOptionRow>
       ))}
       {error && (
-        <HelpText>
+        <ErrorText>
           We are only able to process up to $50,000 online. Want to donate more?{' '}
           <a
             className="underline text-primary"
@@ -113,7 +113,7 @@ const DonationQuickOption: React.FC<Props> = ({
           >
             contact us
           </a>
-        </HelpText>
+        </ErrorText>
       )}
     </QuickOptionContainer>
   );

--- a/src/components/Donation/components/DonationWizard.tsx
+++ b/src/components/Donation/components/DonationWizard.tsx
@@ -18,8 +18,8 @@ export const Input = styled.input`
   ${tw`w-full px-3 py-3 bg-white border rounded-md border-beige-500 focus:outline-none focus:border-blue-200`}
 `;
 
-export const HelpText = styled.p`
-  ${tw`mt-1 text-xs text-gray-100`}
+export const ErrorText = styled.p`
+  ${tw`mt-1 text-xs text-primary-darker`}
 `;
 
 export const ToggleSelector = styled.div`

--- a/src/components/Donation/components/StripeCardInput.tsx
+++ b/src/components/Donation/components/StripeCardInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { HelpText } from './DonationWizard';
+import { ErrorText } from './DonationWizard';
 import {
   Stripe,
   StripeCardElement,
@@ -44,7 +44,7 @@ const StripeCardInput: React.FC<Props> = ({ onChange }) => {
         options={CARD_ELEMENT_OPTIONS}
         onChange={handleOnChange}
       />
-      <HelpText role="alert">{error}</HelpText>
+      <ErrorText role="alert">{error}</ErrorText>
     </>
   );
 };

--- a/src/components/Donation/constants/errors.ts
+++ b/src/components/Donation/constants/errors.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_ERROR = 'Error processing your request. Please try again';

--- a/src/components/Donation/constants/placeholders.ts
+++ b/src/components/Donation/constants/placeholders.ts
@@ -1,0 +1,1 @@
+export const EMPTY_SPACE = ' ';

--- a/src/components/Donation/machines/__tests__/donationMachine.spec.ts
+++ b/src/components/Donation/machines/__tests__/donationMachine.spec.ts
@@ -130,12 +130,12 @@ test('goes into process donation after filling all information', () => {
     cardInformation,
     donation: {
       message: '',
-      status: ''
+      status: '',
+      errors: null
     },
     donationType: 'once',
     donationOnceAmount: donationAmount,
     donationMonthlyAmount: MINIMAL_DONATION,
-    errors: null,
     paymentServices
   });
 });

--- a/src/components/Donation/machines/donationMachine.ts
+++ b/src/components/Donation/machines/donationMachine.ts
@@ -22,12 +22,12 @@ const donationWidgetMachine = Machine<
     context: {
       donation: {
         message: '',
-        status: ''
+        status: '',
+        errors: null
       },
       donationType: 'once',
       donationOnceAmount: MINIMAL_DONATION,
       donationMonthlyAmount: MINIMAL_DONATION,
-      errors: null,
       billingInformation: {
         address: '',
         city: '',
@@ -125,7 +125,12 @@ const donationWidgetMachine = Machine<
           },
           onError: {
             target: 'failure',
-            actions: assign({ errors: (context, event) => event.data })
+            actions: assign<DonationMachineContext, any>({
+              donation: (context, event) => ({
+                status: 'failed',
+                errors: [event.data.message]
+              })
+            })
           }
         }
       },

--- a/src/components/Donation/machines/donationType.ts
+++ b/src/components/Donation/machines/donationType.ts
@@ -76,13 +76,13 @@ export type DonationMachineContext = {
    * A key to hold the response once the donation service respond
    */
   donation: {
-    message: string;
+    message?: string;
     status: string;
+    /**
+     * A key to hold the errors that may be faced while progressing into the widget
+     */
+    errors?: string[] | null;
   };
-  /**
-   * A key to hold the errors that may be faced while progressing into the widget
-   */
-  errors: { [key: string]: [string] } | null;
   /**
    * The type of donation the user is attempting to do
    */

--- a/src/components/Donation/machines/membershipMachine.ts
+++ b/src/components/Donation/machines/membershipMachine.ts
@@ -7,8 +7,7 @@ export const MINIMAL_DONATION = 5;
 
 export const membershipMachineContext = {
   api: {
-    donation: undefined,
-    error: undefined
+    donation: undefined
   },
   donationType: 'month',
   donationMonthlyAmount: MINIMAL_DONATION,
@@ -39,7 +38,7 @@ export type MembershipMachineContext = Omit<
     donation?: {
       status: 'failed' | 'succeeded';
       message?: string;
-      errors?: { [fieldName: string]: [string] };
+      errors?: string[];
     };
   };
   paymentServices: { stripe?: Stripe; stripeToken?: Token };
@@ -280,8 +279,7 @@ const membershipMachine = Machine<
             target: 'success',
             actions: assign<MembershipMachineContext, any>({
               api: (context, event) => ({
-                donation: event.data,
-                error: undefined
+                donation: event.data
               })
             })
           },
@@ -289,7 +287,10 @@ const membershipMachine = Machine<
             target: 'failure',
             actions: assign<MembershipMachineContext, any>({
               api: (context, event) => ({
-                donation: event.data.errors
+                donation: {
+                  status: 'failed',
+                  errors: [event.data.message]
+                }
               })
             })
           }


### PR DESCRIPTION
**What:**
Handle errors in the donation and membership widgets

**Why:**
Closes: https://app.asana.com/0/1168997577035609/1195421059600720/f

**How:**
`Xstate` has an `onError` event which is going to be triggered if some event fails, in this case, the events are the `subscription` and `donation` actions, which are API requests. If there's an error in the middle of the process, that error data will be included in the `event` data and we can reach that data from the machine context


### Notes
I'm currently reading the `message` key from the failed API request, we agreed to use the `errors` array, but, when I saw the errors they were not too descriptive. we may need to update the membership API in order to return different messages in the `message` key

#### Media
https://www.loom.com/share/0daa6f79343c4408a341042e0f095b7d