### PR TITLE
Avoid membership API request if there's no stripe token

### DIFF
--- a/src/components/Donation/__tests__/DonationWidget.spec.tsx
+++ b/src/components/Donation/__tests__/DonationWidget.spec.tsx
@@ -5,6 +5,7 @@ import faker from 'faker';
 import DonationWidget from '../DonationWidget';
 import * as HTTPService from '../api/donation';
 import { MINIMAL_DONATION } from '../machines/donationMachine';
+import * as Stripe from '@stripe/react-stripe-js';
 
 jest.mock('../components/StripeCardInput');
 
@@ -123,6 +124,77 @@ test('send a donation request with all provided information', async () => {
   );
 
   expect(await screen.findByText(donationResponse.message)).toBeInTheDocument();
+});
+
+test('avoid calling membersip api if the stripe token is missing', async () => {
+  const regexAmount = new RegExp(`Paying ${donationAmount}`, 'i');
+  const useStripeMock = Stripe.useStripe as jest.Mock;
+  useStripeMock.mockReturnValue({
+    createToken: jest.fn().mockResolvedValue({ token: { id: null } })
+  });
+
+  render(<DonationWidget />);
+
+  // Give the amount to donate
+  expect(screen.getByText(/choose an amount/i)).toBeInTheDocument();
+  const amountInput = screen.getByRole('radio', {
+    name: `$${donationAmount} USD`
+  });
+  userEvent.click(amountInput);
+  userEvent.click(screen.getByRole('button', { name: /donate/i }));
+
+  // Give the billing address
+  expect(screen.getByText(regexAmount)).toBeInTheDocument();
+
+  userEvent.type(
+    screen.getByRole('textbox', { name: /street/i }),
+    billingInformation.address
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /city/i }),
+    billingInformation.city
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /zip code/i }),
+    billingInformation.zipCode
+  );
+  userEvent.selectOptions(
+    screen.getByRole('combobox', { name: /country/i }),
+    billingInformation.country
+  );
+  userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+  // Give the payment details
+  expect(screen.getByText(regexAmount)).toBeInTheDocument();
+  userEvent.type(
+    screen.getByRole('textbox', { name: /first name/i }),
+    cardInformation.firstName
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /last name/i }),
+    cardInformation.lastName
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /email/i }),
+    cardInformation.email
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /phone/i }),
+    cardInformation.phoneNumber
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: 'stripe-mocked-input-element' }),
+    faker.finance.creditCardNumber()
+  );
+
+  const submitBtn = screen.getByRole('button', { name: /next/i });
+
+  expect(submitBtn).not.toBeDisabled();
+  userEvent.click(submitBtn);
+
+  expect(
+    await screen.findByText(/error processing your request. please try again/i)
+  ).toBeInTheDocument();
 });
 
 test('allows to go back to edit amount', () => {

--- a/src/components/Donation/__tests__/MembershipWidget.spec.tsx
+++ b/src/components/Donation/__tests__/MembershipWidget.spec.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import faker from 'faker';
 import MembershipWidget from '../MembershipWidget';
 import * as HTTPService from '../api/membership';
+import * as Stripe from '@stripe/react-stripe-js';
 
 jest.mock('../components/StripeCardInput');
 jest.mock('../components/DonationCountryDropdown');
@@ -102,7 +103,6 @@ test('allows to skip the payment form and complete flow using zero donation sele
       chapter: 'massachusetts'
     },
     api: {
-      // TODO: check on integration time seems to be something wrong
       donation: undefined,
       errors: undefined
     },
@@ -187,7 +187,6 @@ test('allows to complete flow using an amount donation selection', async () => {
       chapter: 'massachusetts'
     },
     api: {
-      // TODO: check on integration time seems to be something wrong
       donation: undefined,
       errors: undefined
     },
@@ -198,4 +197,77 @@ test('allows to complete flow using an amount donation selection', async () => {
       stripeToken: expect.any(Object)
     }
   });
+});
+
+test('avoid calling membersip api if the stripe token is missing', async () => {
+  const donationAmount = 5;
+  const regexAmount = new RegExp(`Paying ${donationAmount}`, 'i');
+  const useStripeMock = Stripe.useStripe as jest.Mock;
+  useStripeMock.mockReturnValue({
+    createToken: jest.fn().mockResolvedValue({ token: { id: null } })
+  });
+
+  render(<MembershipWidget />);
+
+  // Select an amount
+  userEvent.click(
+    screen.getByRole('radio', { name: `$${donationAmount} USD/mo` })
+  );
+  userEvent.click(screen.getByRole('button', { name: /pay/i }));
+
+  // Give address information
+  expect(screen.getByText(regexAmount)).toBeInTheDocument();
+
+  userEvent.type(
+    screen.getByRole('textbox', { name: /street/i }),
+    addressInformation.street
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /city/i }),
+    addressInformation.city
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /zip code/i }),
+    addressInformation.zipCode
+  );
+  userEvent.selectOptions(
+    screen.getByRole('combobox', { name: /country/i }),
+    addressInformation.country
+  );
+  userEvent.click(screen.getByRole('button', { name: /next/i }));
+
+  // Give personal information
+  expect(screen.getByText(regexAmount)).toBeInTheDocument();
+  userEvent.type(
+    screen.getByRole('textbox', { name: /first name/i }),
+    personalInformation.firstName
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /last name/i }),
+    personalInformation.lastName
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /email/i }),
+    personalInformation.email
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: /phone/i }),
+    personalInformation.phoneNumber
+  );
+  userEvent.selectOptions(
+    screen.getByRole('combobox', { name: /chapter/i }),
+    'massachusetts'
+  );
+  userEvent.type(
+    screen.getByRole('textbox', { name: 'stripe-mocked-input-element' }),
+    faker.finance.creditCardNumber()
+  );
+
+  const submitBtn = screen.getByRole('button', { name: /next/i });
+  expect(submitBtn).not.toBeDisabled();
+  userEvent.click(submitBtn);
+
+  expect(
+    await screen.findByText(/error processing your request. please try again/i)
+  ).toBeInTheDocument();
 });

--- a/src/components/Donation/api/donation.ts
+++ b/src/components/Donation/api/donation.ts
@@ -14,7 +14,7 @@ export const sendDonation = async (context: DonationMachineContext) => {
   const grecaptcha = (window as any).grecaptcha;
   let recaptchaToken;
 
-  if (!grecaptcha) {
+  if (!grecaptcha || !paymentServices.stripeToken?.id) {
     throw new Error(DEFAULT_ERROR);
   }
 

--- a/src/components/Donation/api/membership.ts
+++ b/src/components/Donation/api/membership.ts
@@ -12,11 +12,14 @@ export const sendMembershipDonation = async (
   context: MembershipMachineContext
 ) => {
   const { personalInformation, addressInformation, paymentServices } = context;
+  const amount = context.donationMonthlyAmount;
+  const grecaptcha = (window as any).grecaptcha;
+  const isZeroDollarDonation = amount === 0;
+  const isMissingStripeToken =
+    !isZeroDollarDonation && !paymentServices.stripeToken?.id;
   let recaptchaToken;
 
-  const grecaptcha = (window as any).grecaptcha;
-
-  if (!grecaptcha) {
+  if (!grecaptcha || isMissingStripeToken) {
     throw new Error(DEFAULT_ERROR);
   }
 
@@ -32,7 +35,6 @@ export const sendMembershipDonation = async (
     throw new Error(DEFAULT_ERROR);
   }
 
-  const amount = context.donationMonthlyAmount;
   const data = {
     'g-recaptcha-response-data': recaptchaToken,
     subscription: {

--- a/src/components/Donation/components/DonationPaymentForm.tsx
+++ b/src/components/Donation/components/DonationPaymentForm.tsx
@@ -10,7 +10,6 @@ import StripeCardInput, { DonationPaymentProvider } from './StripeCardInput';
 import { STRIPE_API_KEY } from '../utils/stripe';
 import { DonationDropdown, DonationPhoneInput } from '.';
 import chapters from '../constants/chapters';
-import { EMPTY_SPACE } from '../constants/placeholders';
 import { DEFAULT_ERROR } from '../constants/errors';
 
 export interface Props {
@@ -44,7 +43,7 @@ const DonationPaymentForm: React.FC<Props> = ({
   const [paymentProvider, setPaymentProvider] = useState<
     DonationPaymentProvider | undefined
   >();
-  const errorMessage: string | undefined = errors?.join(EMPTY_SPACE);
+  const errorMessage: string | undefined = errors?.join(' ');
 
   const handleOnSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
     e.persist();

--- a/src/components/Donation/constants/placeholders.ts
+++ b/src/components/Donation/constants/placeholders.ts
@@ -1,1 +1,0 @@
-export const EMPTY_SPACE = ' ';


### PR DESCRIPTION
**What:**
Avoid membership API request if there's no stripe token

**Why:**
Closes: https://app.asana.com/0/1168997577035609/1199557826541445/f

**How:**
Throw an error that will be visible in the UI if there is no stripe token present while submitting the Donation/Membership Widget

#### Media
https://www.loom.com/share/bdcdcb77342a4a11af9eca3980f38ac5
