### PR TITLE
fix(donation-widget): use stripe development token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ yarn-error.log
 
 # Sanity
 studio/dist/
+
+# Local Netlify folder
+.netlify

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -106,6 +106,12 @@ module.exports = {
           type: 'expanded_bubble'
         }
       }
+    },
+    {
+      resolve: `gatsby-plugin-env-variables`,
+      options: {
+        allowList: [`BRANCH`]
+      }
     }
   ]
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,19 +1,12 @@
 # This is used by Netlify via netlify.toml to set environment variables for specific environments
 # https://docs.netlify.com/configure-builds/file-based-configuration/#inject-environment-variable-values
 
-[context.deploy-preview]
-  command='sed -i "s|REPLACE_GATSBY_STRIPE_PUBLIC_TOKEN|${GATSBY_DEVELOPMENT_STRIPE_PUBLIC_TOKEN}|g" netlify.toml && yarn build'
-
 [context.deploy-preview.environment]
   GATSBY_COMMUNITY_URL="https://community-test.debtcollective.org"
   GATSBY_DONATE_API_URL = "https://membership-test.debtcollective.org/donate"
   GATSBY_HOST_URL = "https://development.debtcollective.org"
   GATSBY_MEMBERSHIP_API_URL = "https://membership-test.debtcollective.org/subscriptions"
   GATSBY_MEMBERSHIP_URL = "https://membership-test.debtcollective.org"
-  GATSBY_STRIPE_PUBLIC_TOKEN="REPLACE_GATSBY_STRIPE_PUBLIC_TOKEN"
-
-[context.development]
-  command='sed -i "s|REPLACE_GATSBY_STRIPE_PUBLIC_TOKEN|${GATSBY_DEVELOPMENT_STRIPE_PUBLIC_TOKEN}|g" netlify.toml && cat netlify.toml && yarn build'
 
 [context.development.environment]
   GATSBY_COMMUNITY_URL="https://community-test.debtcollective.org"
@@ -21,4 +14,3 @@
   GATSBY_HOST_URL = "https://development.debtcollective.org"
   GATSBY_MEMBERSHIP_API_URL = "https://membership-test.debtcollective.org/subscriptions"
   GATSBY_MEMBERSHIP_URL = "https://membership-test.debtcollective.org"
-  GATSBY_STRIPE_PUBLIC_TOKEN="REPLACE_GATSBY_STRIPE_PUBLIC_TOKEN"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gatsby-background-image": "^1.1.2",
     "gatsby-image": "^2.4.16",
     "gatsby-plugin-chatwoot": "1.1.0",
+    "gatsby-plugin-env-variables": "^2.0.0",
     "gatsby-plugin-google-fonts": "1.0.1",
     "gatsby-plugin-google-tagmanager": "^2.3.14",
     "gatsby-plugin-postcss": "^2.3.11",

--- a/src/components/Donation/utils/stripe.ts
+++ b/src/components/Donation/utils/stripe.ts
@@ -1,9 +1,12 @@
 import { DonationMachineContext } from '../machines/donationType';
 
+const isProduction = process.env.BRANCH === 'master';
 /**
  * Publishable key that is used in order to load Stripe
  */
-export const STRIPE_API_KEY = `${process.env.GATSBY_STRIPE_PUBLIC_TOKEN}`;
+export const STRIPE_API_KEY = isProduction
+  ? `${process.env.GATSBY_STRIPE_PUBLIC_TOKEN}`
+  : `${process.env.GATSBY_DEVELOPMENT_STRIPE_PUBLIC_TOKEN}`;
 
 /**
  * Add extra data to the create token process to take advantage

--- a/yarn.lock
+++ b/yarn.lock
@@ -11201,6 +11201,11 @@ gatsby-plugin-chatwoot@1.1.0:
   dependencies:
     "@babel/runtime" "^7.8.3"
 
+gatsby-plugin-env-variables@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-env-variables/-/gatsby-plugin-env-variables-2.0.0.tgz#a5641eb61f00490a4043fb64646ab7a631491712"
+  integrity sha512-3scVhM0B6uicDXkf9liLY31DEaRD0UCrYlAgaGuyda4bFDFa7TRN35+sVr1iVIj39ALe4bEc/nu812B82Irjrw==
+
 gatsby-plugin-google-fonts@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-google-fonts/-/gatsby-plugin-google-fonts-1.0.1.tgz#d71054f7bf207b9a8da227380369e18e6f4e0201"


### PR DESCRIPTION
**What:**
Fix the stripe token for development environments

**Why:**
Closes: https://app.asana.com/0/1159164196409156/1199957006065251/f

**How:**
Removing env variables injection from the `netlify.toml` file and use the netlify env variable `BRANCH` to determine which token should be used depending on the deploy environment