### PR TITLE
Fix badges that are using the green color

### DIFF
--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -32,11 +32,11 @@ const Badge: React.FC<Props> = ({
           )}
           alt={imageAlt}
         />
-        <h6 className="text-3xl leading-8 font-semibold text-center text-black uppercase font-more-gothic mt-4 mb-2">
+        <h6 className="mt-4 mb-2 text-3xl font-semibold leading-8 text-center text-black uppercase font-more-gothic">
           {title}
         </h6>
         {text && (
-          <p className="text-lg leading-5 font-semibold text-center text-gray">
+          <p className="text-lg font-semibold leading-5 text-center text-gray">
             {text}
           </p>
         )}

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,7 +1,7 @@
 export enum Colors {
   blue = 'blue',
   gray = 'gray',
-  green = 'green',
+  green100 = 'green-100',
   pink = 'pink',
   primary = 'primary',
   purple = 'purple',

--- a/src/sections/MainSlider/index.tsx
+++ b/src/sections/MainSlider/index.tsx
@@ -37,7 +37,7 @@ const MainSlider = () => {
           },
           {
             alt: 'Take Action',
-            backgroundColor: Colors.green,
+            backgroundColor: Colors.green100,
             href: 'https://bit.ly/help-cancel-student-debt',
             src: thingsToDoIcon,
             text:

--- a/src/sections/MembershipBenefits/index.tsx
+++ b/src/sections/MembershipBenefits/index.tsx
@@ -47,7 +47,7 @@ const MembershipBenefits: React.FC<Props> = ({ title, description }) => {
           },
           {
             alt: 'Local organizing',
-            backgroundColor: Colors.green,
+            backgroundColor: Colors.green100,
             src: localChaptersIcon,
             text:
               'Members are encouraged to lead and take part in local actions and activities around the country!',


### PR DESCRIPTION
**What:**
Fix badges that are using the green color

**Why:**
Relates to: https://app.asana.com/0/1159164196409156/1200177650892561/f

**How:**
The green colors didn't exist anymore, it changed to `green-100`. By updating the color green used by the badges to `green-100` the problem was solved


#### Bug
![image](https://user-images.githubusercontent.com/20747535/114249076-282e5500-995f-11eb-9d3a-6b9e18f7fd21.png)

#### Media
![image](https://user-images.githubusercontent.com/20747535/114249083-2c5a7280-995f-11eb-9029-9fc0133986d6.png)

