### PR TITLE
Fix unknown error while sending a message with existing user

### DIFF
--- a/functions/messages.js
+++ b/functions/messages.js
@@ -62,10 +62,8 @@ exports.handler = async (event) => {
   } = JSON.parse(event.body || {});
   const messenger = new ChatwootMessenger(email, name, message, subject);
 
-  let statusCode = 500;
-  let body = JSON.stringify({
-    message: 'Internal Error'
-  });
+  let statusCode;
+  let body;
 
   if (!email || !name || !message || !subject) {
     return {
@@ -98,45 +96,54 @@ exports.handler = async (event) => {
   } catch (error) {
     await reportError(error);
 
-    if (error instanceof RecaptchaError) {
-      statusCode = 409;
-      body = JSON.stringify({
-        type: 'Recaptcha',
-        message: 'We could not verify you are a human, please try again',
-        status: statusCode
-      });
-    }
-
-    if (error instanceof CreateContactError) {
-      body = JSON.stringify({
-        type: 'Contact',
-        message: 'Something went wrong, please try again',
-        status: statusCode
-      });
-    }
-
-    if (error instanceof CreateConverstaionError) {
-      body = JSON.stringify({
-        type: 'Conversation',
-        message: 'Something went wrong, please try again',
-        status: statusCode
-      });
-    }
-
-    if (error instanceof CreateLabelError) {
-      body = JSON.stringify({
-        type: 'Label',
-        message: 'Something went wrong, please try again',
-        status: statusCode
-      });
-    }
-
-    if (error instanceof CreateMessageError) {
-      body = JSON.stringify({
-        type: 'Message',
-        message: 'Something went wrong, please try again',
-        status: statusCode
-      });
+    switch (true) {
+      case error instanceof RecaptchaError: {
+        statusCode = 409;
+        body = JSON.stringify({
+          type: 'Recaptcha',
+          message: 'We could not verify you are a human, please try again',
+          status: statusCode
+        });
+        break;
+      }
+      case error instanceof CreateContactError: {
+        body = JSON.stringify({
+          type: 'Contact',
+          message: 'Something went wrong, please try again',
+          status: statusCode
+        });
+        break;
+      }
+      case error instanceof CreateConverstaionError: {
+        body = JSON.stringify({
+          type: 'Conversation',
+          message: 'Something went wrong, please try again',
+          status: statusCode
+        });
+        break;
+      }
+      case error instanceof CreateLabelError: {
+        body = JSON.stringify({
+          type: 'Label',
+          message: 'Something went wrong, please try again',
+          status: statusCode
+        });
+        break;
+      }
+      case error instanceof CreateMessageError: {
+        body = JSON.stringify({
+          type: 'Message',
+          message: 'Something went wrong, please try again',
+          status: statusCode
+        });
+        break;
+      }
+      default: {
+        statusCode = 500;
+        body = JSON.stringify({
+          message: 'Internal Error'
+        });
+      }
     }
   }
 

--- a/functions/messenger.js
+++ b/functions/messenger.js
@@ -83,7 +83,7 @@ class ChatwootMessenger {
         this.inboxSourceId = this._findSourceId(contact_inboxes);
       }
     } catch (error) {
-      throw new CreateContactError();
+      throw new CreateContactError(error);
     }
 
     // If email is taken, retrieve contact data
@@ -103,7 +103,7 @@ class ChatwootMessenger {
           this.inboxSourceId = this._findSourceId(user.contact_inboxes);
         }
       } catch (error) {
-        throw new CreateContactError();
+        throw new CreateContactError(error);
       }
     }
   }
@@ -126,7 +126,7 @@ class ChatwootMessenger {
 
       if (response && response.id) this.conversationId = response.id;
     } catch (error) {
-      throw new CreateConverstaionError();
+      throw new CreateConverstaionError(error);
     }
   }
 
@@ -147,7 +147,7 @@ class ChatwootMessenger {
 
       if (!response.payload) throw new CreateLabelError();
     } catch (error) {
-      throw new CreateLabelError();
+      throw new CreateLabelError(error);
     }
   }
 
@@ -170,7 +170,7 @@ class ChatwootMessenger {
 
       return data;
     } catch (error) {
-      throw new CreateMessageError();
+      throw new CreateMessageError(error);
     }
   }
 }

--- a/functions/messenger.js
+++ b/functions/messenger.js
@@ -34,6 +34,7 @@ class ChatwootMessenger {
     this.isEmailTaken = false;
     this.inboxSourceId = null;
     this.conversationId = null;
+    this.userId = null;
   }
 
   _findUser(users, email) {
@@ -45,6 +46,8 @@ class ChatwootMessenger {
     const apiInbox = contactInboxes.find(
       (contactInbox) => contactInbox.inbox.id === Number(CHATWOOT_INBOX_ID)
     );
+
+    if (!apiInbox) return null;
 
     return apiInbox.source_id;
   }
@@ -100,8 +103,30 @@ class ChatwootMessenger {
         const user = this._findUser(response.payload, this.email);
 
         if (user.id) {
+          this.userId = user.id;
           this.inboxSourceId = this._findSourceId(user.contact_inboxes);
         }
+      } catch (error) {
+        throw new CreateContactError(error);
+      }
+    }
+
+    // If user is not in the API inbox, we add it
+    if (!this.inboxSourceId) {
+      try {
+        const data = await fetch(
+          `${CHATWOOT_BASE_URL}/api/v1/accounts/${CHATWOOT_ACCOUNT_ID}/contacts/${this.userId}/contact_inboxes`,
+          {
+            ...BASE_FETCH_OPTIONS,
+            method: 'post',
+            body: JSON.stringify({
+              inbox_id: CHATWOOT_INBOX_ID
+            })
+          }
+        );
+        const response = await data.json();
+
+        this.inboxSourceId = response.source_id;
       } catch (error) {
         throw new CreateContactError(error);
       }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@debtcollective/dc-footer-component": "0.3.0",
-    "@debtcollective/dc-header-component": "2.5.0",
+    "@debtcollective/dc-footer-component": "^0.3.0",
+    "@debtcollective/dc-header-component": "^2.5.0",
     "@debtcollective/union-component": "^1.4.3",
     "@sanity/block-content-to-react": "2.0.7",
     "@sentry/node": "^6.3.0",

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -43,11 +43,6 @@ const HEADER_LINKS = [
     href: 'https://community.debtcollective.org/',
     text: 'Community',
     target: '_blank'
-  },
-  {
-    href: 'https://teespring.com/stores/debt-collective',
-    text: 'Store',
-    target: '_blank'
   }
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,14 +1547,14 @@
   dependencies:
     lodash.omit "^4.5.0"
 
-"@debtcollective/dc-footer-component@0.3.0":
+"@debtcollective/dc-footer-component@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@debtcollective/dc-footer-component/-/dc-footer-component-0.3.0.tgz#7666abb2f3e26d203ff3ec18bda11fde2ee622bb"
   integrity sha512-KnV2aMvbsLdRQlTvQub9Z9dnsuC7LugG4iSFlT7fJUppLv72Oa6MmxaRSxjdUbpGFUDOMs27NJangXlZObkEig==
   dependencies:
     "@stencil/core" "^2.0.1"
 
-"@debtcollective/dc-header-component@2.5.0":
+"@debtcollective/dc-header-component@^2.5.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@debtcollective/dc-header-component/-/dc-header-component-2.5.0.tgz#afe92b7a19bdb4e721f23b2ac2913fe1673ffd57"
   integrity sha512-Vvnuybyi8xNi1WtzlD0VOx7u7uuCrRnHsa+vdQRO15fFhlH1ytVDaPgw6SE2c190WcWQ2uCWQgS55abix6Fj1g==


### PR DESCRIPTION
**What:**
- Send chatwoot error to custom messenger error so it can be mapped by sentry
- Fix unknown error while sending a message with existing user

**Why:**
There was an error where sentry didn't display enough context about the error the chatwoot API returned. We found this was an error related to the create contact step, contacts are supposed to be part of the inbox we are creating a message from. Existing users were not in the new API inbox by default, so we needed a step to add them.

**How:**
- Sending the error returned by sentry in the custom error as param
- If the user was already created in the chatwoot contacts, after retrieving the user information, we add that user to the API inbox to enable creating a conversation
