### PR TITLE
Avoid query community to build site

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -56,18 +56,6 @@ module.exports = {
       }
     },
     {
-      resolve: 'gatsby-source-custom-api',
-      options: {
-        url: `${process.env.GATSBY_COMMUNITY_URL}/about.json`,
-        rootKey: 'about',
-        schemas: {
-          about: `
-            user_count: Int
-          `
-        }
-      }
-    },
-    {
       resolve: 'gatsby-plugin-google-tagmanager',
       options: {
         id: process.env.GOOGLE_TAG_MANAGER_ID,

--- a/src/sections/OweTheBank/index.tsx
+++ b/src/sections/OweTheBank/index.tsx
@@ -27,24 +27,10 @@ const OweTheBank = () => {
           }
         }
       }
-      allAbout {
-        nodes {
-          about {
-            stats {
-              user_count
-            }
-          }
-        }
-      }
     }
   `);
 
-  // Fetch user count from Discourse
-  const {
-    about: {
-      stats: { user_count: userCount }
-    }
-  } = allAbout.nodes[0];
+  const userCount = 10000;
 
   // Art-Direction Array
   const backgroundArtDirectionStack = [
@@ -66,13 +52,13 @@ const OweTheBank = () => {
     >
       <div className="order-2 w-full mx-auto max-w-8xl">
         <p className="text-xl font-semibold text-right text-white lg:text-2xl">
-          With {formatNumberWithCommas(userCount)} members,
+          With +{formatNumberWithCommas(userCount)} members,
         </p>
         <p className="text-xl font-semibold text-right text-white lg:text-2xl">
           together, we own the bank!
         </p>
         <h2 className="mt-2 text-6xl font-bold text-right text-white leading-20 lg:mt-5 lg:text-7xl">
-          {formatNumberWithCommas(userCount)}
+          +{formatNumberWithCommas(userCount)}
         </h2>
       </div>
     </BackgroundImage>


### PR DESCRIPTION
**What:**
Remove query to user count

**Why:**
This represent yet another obstacle to being able to quickly iterate over this debtcollective space. We can avoid the hassle and work on a rewording of the section which will make this far more easier to contribute as there will be no dependencies with the community

**How:**
Remove usage and setup for query community user count

**Media:**
![image](https://user-images.githubusercontent.com/1425162/118136095-06176f00-b404-11eb-942b-1ba5c1d1589b.png)
